### PR TITLE
Update Dockerfile to work with Composer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,4 @@
-.env
-.env.example
-composer.json
-composer.lock
 Dockerfile
 README.md
 .gitignore
+vendor

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /config.php
 .DS_Store
 .env
+/composer.phar

--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,4 @@
+<FilesMatch ".env|.env.example">
+  Order allow,deny
+  Deny from all
+</FilesMatch>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,21 @@
 FROM php:7.0-apache
 
-COPY ./ /var/www/html/
+COPY . /var/www/html # Copies all file project in the container
+WORKDIR /var/www/html
+
+RUN useradd -ms /bin/bash slackemon && \ # Create a user
+    usermod -a -G www-data slackemon && \ # Assign it to www-data
+    chown -R www-data:www-data /var/www/html && \ # Assign public_html to www-data
+    chmod -R 774 /var/www/html # Change permission to only user and group www-data
+
+RUN apt-get update && apt-get install git zlib1g-dev -y && \ # Install git and zip, used by Composer
+    docker-php-ext-install zip && \ # Install zip
+    curl -s http://getcomposer.org/installer | php # Install package manager Composer
+
+USER slackemon 
+
+RUN php composer.phar install # Install dependencies as non-root
+
+VOLUME /var/www/html/vendor # Separate container vendor from local vendor
+
+USER root # Use root to start the server

--- a/config.sample.php
+++ b/config.sample.php
@@ -10,6 +10,13 @@
 // Configuration via environment variables is also available. If you want to use env vars instead, there is no need to
 // copy or edit this file - just ensure you define each of the constants referenced below.
 
+// require __DIR__ . '/vendor/autoload.php';
+
+// use Dotenv\Dotenv;
+
+// $dotenv = new Dotenv(__DIR__);
+// $dotenv->load();
+
 // Slack App token
 define( 'SLACK_TOKEN_TXXXXXXXX', 'XXXXXXXXXXXXXXXXXXXXXXXX' );
 

--- a/init.php
+++ b/init.php
@@ -18,8 +18,6 @@ if ( file_exists( __DIR__ . '/config.php' ) ) {
 	require_once( __DIR__ . '/config.php' );
 } else {
 	exit( 'Missing local config file. Have you copied the sample config?' );
-} else {
-	exit( 'Missing local config file. Have you copied the sample config?' );
 }
 
 // Set some config variables in stone


### PR DESCRIPTION
Hi, you can build the image as usual with

`docker build -t slackemon .`

and start a server with

 `docker run -p 80:80 -v ${PWD}:/var/www/html -it --rm --env-file ./.env --name slackemonInstance slackemon`

The -v switch allows you to mount a local volume to the Docker container, so one can modify local files and those will sync in the Docker container, so development becomes quicker.

I think we should create a wrapper around Dotenv. In a way that first env vars should be fetched by memory using PHP native [getenv](http://php.net/manual/it/function.getenv.php), if not present using Dotenv.