### PR TITLE
Fix comments in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,34 @@
 FROM php:7.0-apache
 
-COPY . /var/www/html # Copies all file project in the container
+COPY . /var/www/html
 WORKDIR /var/www/html
 
-RUN useradd -ms /bin/bash slackemon && \ # Create a user
-    usermod -a -G www-data slackemon && \ # Assign it to www-data
-    chown -R www-data:www-data /var/www/html && \ # Assign public_html to www-data
-    chmod -R 774 /var/www/html # Change permission to only user and group www-data
+# Create a user
+RUN useradd -ms /bin/bash slackemon
 
-RUN apt-get update && apt-get install git zlib1g-dev -y && \ # Install git and zip, used by Composer
-    docker-php-ext-install zip && \ # Install zip
-    curl -s http://getcomposer.org/installer | php # Install package manager Composer
+# Assign it to www-data
+RUN usermod -a -G www-data slackemon
 
-USER slackemon 
+# Assign public_html to www-data
+RUN chown -R www-data:www-data /var/www/html
 
-RUN php composer.phar install # Install dependencies as non-root
+# Change permission to only user and group www-data
+RUN chmod -R 774 /var/www/html
 
-VOLUME /var/www/html/vendor # Separate container vendor from local vendor
+# Install git and zip, used by Composer
+RUN apt-get update && apt-get install git zlib1g-dev -y && \ 
+    docker-php-ext-install zip
 
-USER root # Use root to start the server
+# Install package manager Composer
+RUN curl -s http://getcomposer.org/installer | php
+
+USER slackemon
+
+# Install dependencies as non-root
+RUN php composer.phar install
+
+# Separate container vendor from local vendor
+VOLUME /var/www/html/vendor
+
+# Use root to start the server
+USER root


### PR DESCRIPTION
I leave here another time the instruction to run it.

```
docker build -t slackemon .
docker run -p 80:80 -v ${PWD}:/var/www/html -it --rm --env-file ./.env --name slackemonInstance slackemon
```
I'm on windows, so `${PWD}` gives me the absolute current path of my drectory. On linux you have to change it.

Additionally, you can fire a new shell and inspect `slackemonInstance `with:
```
docker exec -it slackemonInstance bash
```