### PR TITLE
Adds cron support to Docker installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ RUN chown -R www-data:www-data /var/www/html
 # Change permission to only user and group www-data
 RUN chmod -R 774 /var/www/html
 
-# Install git and zip, used by Composer
-RUN apt-get update && apt-get install git zlib1g-dev -y && \ 
+# Install git and zip, used by Composer, cron and nano
+RUN apt-get update && apt-get install git zlib1g-dev cron nano -y && \ 
     docker-php-ext-install zip
 
 # Install package manager Composer
@@ -32,3 +32,10 @@ VOLUME /var/www/html/vendor
 
 # Use root to start the server
 USER root
+
+# Set up the cron job every minute, with the correct environment
+# then, start apache2 in foreground (https://github.com/docker-library/php/blob/76a1c5ca161f1ed6aafb2c2d26f83ec17360bc68/7.1/apache/Dockerfile#L205)
+CMD printenv > /etc/environment && \
+    echo "* * * * * php cron.php --token=$SLACKEMON_CRON_TOKEN" | crontab - && \
+    cron && \
+    apache2-foreground


### PR DESCRIPTION
Hi, this PR enables cron to run every minute, invoking the following command

```
php cron.php --token=$SLACKEMON_CRON_TOKEN
```

Is it correct to run it every minute? (`* * * * *`)
Or this should be user-customizable? Right now it is hard-coded