### PR TITLE
Initial Compose support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "2"
+services:
+  slackemon_webserver:
+    build: .
+    restart: always
+    volumes: 
+      - ./:/var/www/html
+    ports:
+      - "80:80"
+
+  slackemon_db:
+    image: postgres:alpine
+    restart: always
+    expose:
+      - "5432"
+    volumes:
+      - slackemon_db_data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=slackemon
+      - POSTGRES_USER=slackemon
+      - PGDATA=/var/lib/postgresql/data/pgdata
+
+# Local volume where to store data
+# in a persistent way
+volumes:
+  slackemon_db_data:


### PR DESCRIPTION
Hi, in this PR there is only PostgreSQL alpine.

We will need further work to add PHP and httpd. For now, let's check if our base image can connect with PostgreSQL.

The connection string a user should use is: 

> postgres://slackemon:slackemon@slackemon_db:5432/slackemon

Right now user, password, host, and database have quite the same names, should we differentiate them a little bit?

Oh, to deploy the containers: `docker-compose up`, to remove them: `docker-compose down`. To start detached add `-d` switch
