### PR TITLE
Updates deny section

### DIFF
--- a/etc/nginx/default.conf
+++ b/etc/nginx/default.conf
@@ -6,7 +6,7 @@ server {
     access_log /var/log/nginx/access.log;
     root /slackemon;
 
-    location ~ /\. {
+    location ~ /\.env {
         deny all;
     }
 


### PR DESCRIPTION
In Docker images are not loaded because Nginx filters all request which starts with a dot